### PR TITLE
Revert "chore(deps): update helm release longhorn to v1.11.2"

### DIFF
--- a/apps/base/longhorn/kustomization.yaml
+++ b/apps/base/longhorn/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 helmCharts:
   - name: longhorn
     repo: https://charts.longhorn.io/
-    version: 1.11.2
+    version: v1.8.0
     releaseName: longhorn
     namespace: longhorn
     valuesFile: values.yaml


### PR DESCRIPTION
Reverts alfiemellor/homelab#6

Longhorn is unable to update over multiple minor versions at once.